### PR TITLE
Enable custom file handlers for Monitor

### DIFF
--- a/internal/monitor/enhanced_monitor.go
+++ b/internal/monitor/enhanced_monitor.go
@@ -52,6 +52,8 @@ func NewEnhancedMonitor(config EnhancedConfig) (*EnhancedMonitor, error) {
 		pauseChan: make(chan bool),
 	}
 
+	em.fileHandler = em.processFile
+
 	// Initialize batch processor if enabled
 	if config.EnableBatching {
 		em.batchProcessor = NewBatchProcessor(


### PR DESCRIPTION
## Summary
- allow `Monitor` to delegate file processing via `fileHandler`
- default to `processFile` in `NewMonitor`
- invoke enhanced logic by setting `em.fileHandler` in `NewEnhancedMonitor`
- use `fileHandler` when reacting to events

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b255c975c832299c167e160eb5dcf